### PR TITLE
Rewrite factorio api version logic

### DIFF
--- a/src/main/java/moe/knox/factorio/core/NotificationService.java
+++ b/src/main/java/moe/knox/factorio/core/NotificationService.java
@@ -38,6 +38,10 @@ final public class NotificationService {
         raiseNotification("Error downloading Version overview", NotificationType.WARNING);
     }
 
+    public void notifyErrorDownloadingApi() {
+        raiseNotification("Error downloading api", NotificationType.ERROR);
+    }
+
     public void notifyErrorDownloadingPrototypeDefinitions() {
         raiseNotification("""
             Error downloading the factorio prototype definitions. Please go online and try it again!

--- a/src/main/java/moe/knox/factorio/core/parser/ApiParser.java
+++ b/src/main/java/moe/knox/factorio/core/parser/ApiParser.java
@@ -81,7 +81,7 @@ public class ApiParser extends Parser {
         FactorioAutocompletionState config = FactorioAutocompletionState.getInstance(project);
         String apiPath = apiRootPath + config.selectedFactorioVersion.link;
 
-        if (config.selectedFactorioVersion.desc.equals("Latest version")) {
+        if (config.selectedFactorioVersion.isLatest()) {
             Document doc = null;
             try {
                 doc = Jsoup.connect("https://lua-api.factorio.com/").get();

--- a/src/main/java/moe/knox/factorio/core/parser/ApiParser.java
+++ b/src/main/java/moe/knox/factorio/core/parser/ApiParser.java
@@ -128,9 +128,6 @@ public class ApiParser extends Parser {
             // whole thing finished, reload the Library-Provider
             ApplicationManager.getApplication().invokeLater(() -> FactorioLibraryProvider.reload());
         }
-        catch (Throwable e) {
-            NotificationService.getInstance(myProject).notifyErrorDownloadingApi();
-        }
         finally {
             downloadInProgress.set(false);
             indicator.stop();

--- a/src/main/java/moe/knox/factorio/core/parser/ApiParser.java
+++ b/src/main/java/moe/knox/factorio/core/parser/ApiParser.java
@@ -120,16 +120,23 @@ public class ApiParser extends Parser {
      */
     @Override
     public void run(@NotNull ProgressIndicator indicator) {
-        this.indicator = indicator;
-        config = FactorioAutocompletionState.getInstance(myProject);
+        try {
+            this.indicator = indicator;
+            config = FactorioAutocompletionState.getInstance(myProject);
 
-        // start the whole thing
-        assureDir();
+            // start the whole thing
+            assureDir();
 
-        downloadInProgress.set(false);
-
-        // whole thing finished, reload the Library-Provider
-        ApplicationManager.getApplication().invokeLater(() -> FactorioLibraryProvider.reload());
+            // whole thing finished, reload the Library-Provider
+            ApplicationManager.getApplication().invokeLater(() -> FactorioLibraryProvider.reload());
+        }
+        catch (Throwable e) {
+            NotificationService.getInstance(myProject).notifyErrorDownloadingApi();
+        }
+        finally {
+            downloadInProgress.set(false);
+            indicator.stop();
+        }
     }
 
     public class Attribute {

--- a/src/main/java/moe/knox/factorio/core/parser/ApiParser.java
+++ b/src/main/java/moe/knox/factorio/core/parser/ApiParser.java
@@ -85,7 +85,7 @@ public class ApiParser extends Parser {
         String apiPath = apiRootPath + config.selectedFactorioVersion.version();
 
         if (config.useLatestVersion) {
-            var newestVersion = detectNewestAllowedVersion(project);
+            var newestVersion = detectLatestAllowedVersion(project);
 
             if (newestVersion != null && !newestVersion.equals(config.selectedFactorioVersion)) {
                 // new version detected, update it
@@ -97,7 +97,7 @@ public class ApiParser extends Parser {
         }
     }
 
-    private static FactorioApiVersion detectNewestAllowedVersion(Project project)
+    private static FactorioApiVersion detectLatestAllowedVersion(Project project)
     {
         ApiVersionCollection factorioApiVersions;
 

--- a/src/main/java/moe/knox/factorio/core/parser/ApiParser.java
+++ b/src/main/java/moe/knox/factorio/core/parser/ApiParser.java
@@ -53,7 +53,7 @@ public class ApiParser extends Parser {
         }
 
         FactorioAutocompletionState config = FactorioAutocompletionState.getInstance(project);
-        String apiPath = apiRootPath + config.selectedFactorioVersion.link;
+        String apiPath = apiRootPath + config.selectedFactorioVersion.link();
 
         // check if API is downloaded
         File apiPathFile = new File(apiPath);
@@ -71,7 +71,7 @@ public class ApiParser extends Parser {
     public static void removeCurrentAPI(Project project) {
         if (!downloadInProgress.get()) {
             FactorioAutocompletionState config = FactorioAutocompletionState.getInstance(project);
-            String apiPath = apiRootPath + config.selectedFactorioVersion.link;
+            String apiPath = apiRootPath + config.selectedFactorioVersion.link();
             FileUtil.delete(new File(apiPath));
             FactorioLibraryProvider.reload();
         }
@@ -79,7 +79,7 @@ public class ApiParser extends Parser {
 
     public static void checkForUpdate(Project project) {
         FactorioAutocompletionState config = FactorioAutocompletionState.getInstance(project);
-        String apiPath = apiRootPath + config.selectedFactorioVersion.link;
+        String apiPath = apiRootPath + config.selectedFactorioVersion.link();
 
         if (config.selectedFactorioVersion.isLatest()) {
             Document doc = null;
@@ -658,7 +658,7 @@ public class ApiParser extends Parser {
      * Here also the indicator will be updated, to show the current percentage of the parsing.
      */
     private void downloadAndParseAPI() {
-        String versionedApiLink = factorioApiBaseLink + config.selectedFactorioVersion.link;
+        String versionedApiLink = factorioApiBaseLink + config.selectedFactorioVersion.link();
 
         indicator.setIndeterminate(false);
 

--- a/src/main/java/moe/knox/factorio/core/parser/ApiParser.java
+++ b/src/main/java/moe/knox/factorio/core/parser/ApiParser.java
@@ -55,8 +55,7 @@ public class ApiParser extends Parser {
             return null;
         }
 
-        FactorioAutocompletionState config = FactorioAutocompletionState.getInstance(project);
-        String apiPath = apiRootPath + config.selectedFactorioVersion.version();
+        String apiPath = getSelectedApiVersionFilePath(project);
 
         // check if API is downloaded
         File apiPathFile = new File(apiPath);
@@ -73,8 +72,7 @@ public class ApiParser extends Parser {
 
     public static void removeCurrentAPI(Project project) {
         if (!downloadInProgress.get()) {
-            FactorioAutocompletionState config = FactorioAutocompletionState.getInstance(project);
-            String apiPath = apiRootPath + config.selectedFactorioVersion.version();
+            String apiPath = getSelectedApiVersionFilePath(project);
             FileUtil.delete(new File(apiPath));
             FactorioLibraryProvider.reload();
         }
@@ -82,7 +80,7 @@ public class ApiParser extends Parser {
 
     public static void checkForUpdate(Project project) {
         FactorioAutocompletionState config = FactorioAutocompletionState.getInstance(project);
-        String apiPath = apiRootPath + config.selectedFactorioVersion.version();
+        String apiPath = getSelectedApiVersionFilePath(project);
 
         if (config.useLatestVersion) {
             var newestVersion = detectLatestAllowedVersion(project);
@@ -1110,5 +1108,12 @@ public class ApiParser extends Parser {
 
         String globalsFile = saveDir + "globals.lua";
         saveStringToFile(globalsFile, globalsFileContent.toString());
+    }
+
+    private static String getSelectedApiVersionFilePath(Project project)
+    {
+        var config = FactorioAutocompletionState.getInstance(project);
+
+        return apiRootPath + config.selectedFactorioVersion.version();
     }
 }

--- a/src/main/java/moe/knox/factorio/core/parser/ApiParser.java
+++ b/src/main/java/moe/knox/factorio/core/parser/ApiParser.java
@@ -53,7 +53,7 @@ public class ApiParser extends Parser {
         }
 
         FactorioAutocompletionState config = FactorioAutocompletionState.getInstance(project);
-        String apiPath = apiRootPath + config.selectedFactorioVersion.link();
+        String apiPath = apiRootPath + config.selectedFactorioVersion.version();
 
         // check if API is downloaded
         File apiPathFile = new File(apiPath);
@@ -71,7 +71,7 @@ public class ApiParser extends Parser {
     public static void removeCurrentAPI(Project project) {
         if (!downloadInProgress.get()) {
             FactorioAutocompletionState config = FactorioAutocompletionState.getInstance(project);
-            String apiPath = apiRootPath + config.selectedFactorioVersion.link();
+            String apiPath = apiRootPath + config.selectedFactorioVersion.version();
             FileUtil.delete(new File(apiPath));
             FactorioLibraryProvider.reload();
         }
@@ -79,9 +79,9 @@ public class ApiParser extends Parser {
 
     public static void checkForUpdate(Project project) {
         FactorioAutocompletionState config = FactorioAutocompletionState.getInstance(project);
-        String apiPath = apiRootPath + config.selectedFactorioVersion.link();
+        String apiPath = apiRootPath + config.selectedFactorioVersion.version();
 
-        if (config.selectedFactorioVersion.isLatest()) {
+        if (config.selectedFactorioVersion.latest()) {
             Document doc = null;
             try {
                 doc = Jsoup.connect("https://lua-api.factorio.com/").get();
@@ -658,7 +658,7 @@ public class ApiParser extends Parser {
      * Here also the indicator will be updated, to show the current percentage of the parsing.
      */
     private void downloadAndParseAPI() {
-        String versionedApiLink = factorioApiBaseLink + config.selectedFactorioVersion.link();
+        String versionedApiLink = factorioApiBaseLink + config.selectedFactorioVersion.version();
 
         indicator.setIndeterminate(false);
 

--- a/src/main/java/moe/knox/factorio/core/parser/LuaLibParser.java
+++ b/src/main/java/moe/knox/factorio/core/parser/LuaLibParser.java
@@ -65,8 +65,8 @@ public class LuaLibParser extends Parser {
         }
 
         FactorioAutocompletionState config = FactorioAutocompletionState.getInstance(project);
-        String lualibPath = luaLibRootPath + config.selectedFactorioVersion.link();
-        String prototypePath = prototypeRootPath + config.selectedFactorioVersion.link();
+        String lualibPath = luaLibRootPath + config.selectedFactorioVersion.version();
+        String prototypePath = prototypeRootPath + config.selectedFactorioVersion.version();
 
         File lualibFile = new File(lualibPath);
         File prototypeFile = new File(prototypePath);
@@ -107,13 +107,13 @@ public class LuaLibParser extends Parser {
      */
     public static boolean checkForUpdate(Project project) {
         FactorioAutocompletionState config = FactorioAutocompletionState.getInstance(project);
-        String lualibPath = luaLibRootPath + config.selectedFactorioVersion.link();
-        String prototypePath = prototypeRootPath + config.selectedFactorioVersion.link();
+        String lualibPath = luaLibRootPath + config.selectedFactorioVersion.version();
+        String prototypePath = prototypeRootPath + config.selectedFactorioVersion.version();
 
         File lualibFile = new File(lualibPath);
         File prototypeFile = new File(prototypePath);
         if (lualibFile.exists() && prototypeFile.exists()) {
-            if (config.selectedFactorioVersion.isLatest()) {
+            if (config.selectedFactorioVersion.latest()) {
                 RefTag[] tags = downloadTags();
                 if (tags != null) {
                     String tag = tags[tags.length - 1].ref;
@@ -160,11 +160,11 @@ public class LuaLibParser extends Parser {
         if (tags != null) {
             // find correct Tag
             RefTag correctTag = null;
-            if (config.selectedFactorioVersion.isLatest()) {
+            if (config.selectedFactorioVersion.latest()) {
                 correctTag = tags[tags.length - 1];
             } else {
                 for (RefTag tag : tags) {
-                    if (tag.ref.substring(tag.ref.lastIndexOf("/") + 1).equals(config.selectedFactorioVersion.desc())) {
+                    if (tag.ref.substring(tag.ref.lastIndexOf("/") + 1).equals(config.selectedFactorioVersion.version())) {
                         correctTag = tag;
                         break;
                     }

--- a/src/main/java/moe/knox/factorio/core/parser/LuaLibParser.java
+++ b/src/main/java/moe/knox/factorio/core/parser/LuaLibParser.java
@@ -113,7 +113,7 @@ public class LuaLibParser extends Parser {
         File lualibFile = new File(lualibPath);
         File prototypeFile = new File(prototypePath);
         if (lualibFile.exists() && prototypeFile.exists()) {
-            if (config.selectedFactorioVersion.desc.equals("Latest version")) {
+            if (config.selectedFactorioVersion.isLatest()) {
                 RefTag[] tags = downloadTags();
                 if (tags != null) {
                     String tag = tags[tags.length - 1].ref;
@@ -160,7 +160,7 @@ public class LuaLibParser extends Parser {
         if (tags != null) {
             // find correct Tag
             RefTag correctTag = null;
-            if (config.selectedFactorioVersion.desc.equals("Latest version")) {
+            if (config.selectedFactorioVersion.isLatest()) {
                 correctTag = tags[tags.length - 1];
             } else {
                 for (RefTag tag : tags) {

--- a/src/main/java/moe/knox/factorio/core/parser/LuaLibParser.java
+++ b/src/main/java/moe/knox/factorio/core/parser/LuaLibParser.java
@@ -65,8 +65,8 @@ public class LuaLibParser extends Parser {
         }
 
         FactorioAutocompletionState config = FactorioAutocompletionState.getInstance(project);
-        String lualibPath = luaLibRootPath + config.selectedFactorioVersion.link;
-        String prototypePath = prototypeRootPath + config.selectedFactorioVersion.link;
+        String lualibPath = luaLibRootPath + config.selectedFactorioVersion.link();
+        String prototypePath = prototypeRootPath + config.selectedFactorioVersion.link();
 
         File lualibFile = new File(lualibPath);
         File prototypeFile = new File(prototypePath);
@@ -107,8 +107,8 @@ public class LuaLibParser extends Parser {
      */
     public static boolean checkForUpdate(Project project) {
         FactorioAutocompletionState config = FactorioAutocompletionState.getInstance(project);
-        String lualibPath = luaLibRootPath + config.selectedFactorioVersion.link;
-        String prototypePath = prototypeRootPath + config.selectedFactorioVersion.link;
+        String lualibPath = luaLibRootPath + config.selectedFactorioVersion.link();
+        String prototypePath = prototypeRootPath + config.selectedFactorioVersion.link();
 
         File lualibFile = new File(lualibPath);
         File prototypeFile = new File(prototypePath);
@@ -164,7 +164,7 @@ public class LuaLibParser extends Parser {
                 correctTag = tags[tags.length - 1];
             } else {
                 for (RefTag tag : tags) {
-                    if (tag.ref.substring(tag.ref.lastIndexOf("/") + 1).equals(config.selectedFactorioVersion.desc)) {
+                    if (tag.ref.substring(tag.ref.lastIndexOf("/") + 1).equals(config.selectedFactorioVersion.desc())) {
                         correctTag = tag;
                         break;
                     }

--- a/src/main/java/moe/knox/factorio/core/version/ApiVersionCollection.java
+++ b/src/main/java/moe/knox/factorio/core/version/ApiVersionCollection.java
@@ -1,0 +1,14 @@
+package moe.knox.factorio.core.version;
+
+import java.util.Collections;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+public final class ApiVersionCollection extends TreeSet<FactorioApiVersion> {
+    public FactorioApiVersion latestVersion()
+    {
+        return stream()
+                .filter(FactorioApiVersion::latest)
+                .collect(Collectors.collectingAndThen(Collectors.toSet(), Collections::max));
+    }
+}

--- a/src/main/java/moe/knox/factorio/core/version/ApiVersionCollection.java
+++ b/src/main/java/moe/knox/factorio/core/version/ApiVersionCollection.java
@@ -1,10 +1,13 @@
 package moe.knox.factorio.core.version;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Collections;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 public final class ApiVersionCollection extends TreeSet<FactorioApiVersion> {
+    @NotNull
     public FactorioApiVersion latestVersion()
     {
         return stream()

--- a/src/main/java/moe/knox/factorio/core/version/ApiVersionResolver.java
+++ b/src/main/java/moe/knox/factorio/core/version/ApiVersionResolver.java
@@ -15,7 +15,7 @@ import java.util.TreeSet;
  * @see FactorioApiVersion
  */
 public final class ApiVersionResolver {
-    final private SemVer minimalSupportedVersion = new SemVer("1.1.36", 1, 1, 36);
+    final private SemVer minimalSupportedVersion = new SemVer("1.1.62", 1, 1, 62);
     final private static String versionsHtmlPage = "https://lua-api.factorio.com/";
 
     public ApiVersionCollection supportedVersions() throws IOException {

--- a/src/main/java/moe/knox/factorio/core/version/ApiVersionResolver.java
+++ b/src/main/java/moe/knox/factorio/core/version/ApiVersionResolver.java
@@ -1,0 +1,39 @@
+package moe.knox.factorio.core.version;
+
+import com.intellij.util.text.SemVer;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Return collection of supported api versions
+ * @see FactorioApiVersion
+ */
+public final class ApiVersionResolver {
+    final private SemVer minimalSupportedVersion = new SemVer("1.1.36", 1, 1, 36);
+    final private static String versionsHtmlPage = "https://lua-api.factorio.com/";
+
+    public ApiVersionCollection supportedVersions() throws IOException {
+        var supportedVersions = new ApiVersionCollection();
+
+        Document mainPageDoc = Jsoup.connect(versionsHtmlPage).get();
+        Elements allLinks = mainPageDoc.select("a");
+        for (Element link : allLinks) {
+            var semVer = SemVer.parseFromText(link.text());
+            if (semVer == null || !semVer.isGreaterOrEqualThan(minimalSupportedVersion)) {
+                continue;
+            }
+
+            var factorioVersion = FactorioApiVersion.createVersion(semVer.getRawVersion());
+
+            supportedVersions.add(factorioVersion);
+        }
+
+        return supportedVersions;
+    }
+}

--- a/src/main/java/moe/knox/factorio/core/version/ApiVersionResolver.java
+++ b/src/main/java/moe/knox/factorio/core/version/ApiVersionResolver.java
@@ -7,6 +7,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -19,21 +20,44 @@ public final class ApiVersionResolver {
     final private static String versionsHtmlPage = "https://lua-api.factorio.com/";
 
     public ApiVersionCollection supportedVersions() throws IOException {
+        var allVersions = getAllVersions();
+        var lastVersion = Collections.max(allVersions);
         var supportedVersions = new ApiVersionCollection();
 
-        Document mainPageDoc = Jsoup.connect(versionsHtmlPage).get();
-        Elements allLinks = mainPageDoc.select("a");
-        for (Element link : allLinks) {
-            var semVer = SemVer.parseFromText(link.text());
-            if (semVer == null || !semVer.isGreaterOrEqualThan(minimalSupportedVersion)) {
+        for (SemVer version : allVersions) {
+            if (!version.isGreaterOrEqualThan(minimalSupportedVersion)) {
                 continue;
             }
 
-            var factorioVersion = FactorioApiVersion.createVersion(semVer.getRawVersion());
+            FactorioApiVersion factorioVersion;
+
+            if (version.equals(lastVersion)) {
+                factorioVersion = FactorioApiVersion.createLatestVersion(version.getRawVersion());
+            } else {
+                factorioVersion = FactorioApiVersion.createVersion(version.getRawVersion());
+            }
 
             supportedVersions.add(factorioVersion);
         }
 
         return supportedVersions;
+    }
+
+    private Set<SemVer> getAllVersions()  throws IOException
+    {
+        var versions = new TreeSet<SemVer>();
+
+        Document mainPageDoc = Jsoup.connect(versionsHtmlPage).get();
+        Elements allLinks = mainPageDoc.select("a");
+        for (Element link : allLinks) {
+            var semVer = SemVer.parseFromText(link.text());
+            if (semVer == null) {
+                continue;
+            }
+
+            versions.add(semVer);
+        }
+
+        return versions;
     }
 }

--- a/src/main/java/moe/knox/factorio/core/version/FactorioApiVersion.java
+++ b/src/main/java/moe/knox/factorio/core/version/FactorioApiVersion.java
@@ -6,20 +6,9 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Objects;
 
 public record FactorioApiVersion(String version, boolean latest) implements Comparable<FactorioApiVersion> {
-    private static final String latestVersion = "latest";
-
     @Override
     public String toString() {
-        if (latest) {
-            return "Latest version";
-        }
-
         return version;
-    }
-
-    public static FactorioApiVersion createLatest()
-    {
-        return new FactorioApiVersion(latestVersion, true);
     }
 
     public static FactorioApiVersion createVersion(String version)

--- a/src/main/java/moe/knox/factorio/core/version/FactorioApiVersion.java
+++ b/src/main/java/moe/knox/factorio/core/version/FactorioApiVersion.java
@@ -27,6 +27,11 @@ public record FactorioApiVersion(String version, boolean latest) implements Comp
         return new FactorioApiVersion(version, false);
     }
 
+    public static FactorioApiVersion createLatestVersion(String version)
+    {
+        return new FactorioApiVersion(version, true);
+    }
+
     @Override
     public int compareTo(@NotNull FactorioApiVersion o) {
         SemVer verA = Objects.requireNonNull(SemVer.parseFromText(version));

--- a/src/main/java/moe/knox/factorio/core/version/FactorioApiVersion.java
+++ b/src/main/java/moe/knox/factorio/core/version/FactorioApiVersion.java
@@ -1,6 +1,11 @@
 package moe.knox.factorio.core.version;
 
-public record FactorioApiVersion(String version, boolean latest) {
+import com.intellij.util.text.SemVer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public record FactorioApiVersion(String version, boolean latest) implements Comparable<FactorioApiVersion> {
     private static final String latestVersion = "latest";
 
     @Override
@@ -20,5 +25,13 @@ public record FactorioApiVersion(String version, boolean latest) {
     public static FactorioApiVersion createVersion(String version)
     {
         return new FactorioApiVersion(version, false);
+    }
+
+    @Override
+    public int compareTo(@NotNull FactorioApiVersion o) {
+        SemVer verA = Objects.requireNonNull(SemVer.parseFromText(version));
+        SemVer verB = Objects.requireNonNull(SemVer.parseFromText(o.version));
+
+        return verA.compareTo(verB);
     }
 }

--- a/src/main/java/moe/knox/factorio/core/version/FactorioApiVersion.java
+++ b/src/main/java/moe/knox/factorio/core/version/FactorioApiVersion.java
@@ -1,0 +1,24 @@
+package moe.knox.factorio.core.version;
+
+public record FactorioApiVersion(String version, boolean latest) {
+    private static final String latestVersion = "latest";
+
+    @Override
+    public String toString() {
+        if (latest) {
+            return "Latest version";
+        }
+
+        return version;
+    }
+
+    public static FactorioApiVersion createLatest()
+    {
+        return new FactorioApiVersion(latestVersion, true);
+    }
+
+    public static FactorioApiVersion createVersion(String version)
+    {
+        return new FactorioApiVersion(version, false);
+    }
+}

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
@@ -116,6 +116,8 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
 
         reloadButton.setEnabled(enableIntegration);
 
+        config.useLatestVersion = config.selectedFactorioVersion.latest();
+
         WriteAction.run(() -> FactorioLibraryProvider.reload());
     }
 }

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Objects;
 
@@ -26,11 +27,14 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
     private JLabel loadError;
     private JButton reloadButton;
     private final ApiVersionResolver apiVersionResolver;
+    @NotNull
+    private final FactorioApiVersion latestExistsVersion;
 
-    public FactorioAutocompletionConfig(@NotNull Project project) {
+    public FactorioAutocompletionConfig(@NotNull Project project) throws IOException {
         this.project = project;
         config = FactorioAutocompletionState.getInstance(project);
         apiVersionResolver = new ApiVersionResolver();
+        latestExistsVersion = apiVersionResolver.supportedVersions().latestVersion();
 
         enableFactorioIntegrationCheckBox.setSelected(config.integrationActive);
 
@@ -146,6 +150,10 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
 
     private FactorioApiVersion getSelectedVersion() {
         var dropdownVersion = Objects.requireNonNull((DropdownVersion) selectApiVersion.getSelectedItem());
+
+        if (dropdownVersion.isLatest()) {
+            return latestExistsVersion;
+        }
 
         return FactorioApiVersion.createVersion(dropdownVersion.version);
     }

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
@@ -78,7 +78,7 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
                 continue;
             }
 
-            var factorioVersion = new FactorioVersion(link.text(), link.attr("href"));
+            var factorioVersion = FactorioVersion.createVersion(semVer.getRawVersion());
 
             selectApiVersion.addItem(factorioVersion);
         }

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
@@ -38,7 +38,7 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
             Document mainPageDoc = Jsoup.connect(ApiParser.factorioApiBaseLink).get();
             Elements allLinks = mainPageDoc.select("a");
             for (Element link : allLinks) {
-                FactorioVersion factorioVersion = new FactorioVersion(link.text(), link.attr("href"));
+                var factorioVersion = new FactorioVersion(link.text(), link.attr("href"));
                 selectApiVersion.addItem(factorioVersion);
             }
             selectApiVersion.setSelectedItem(config.selectedFactorioVersion);

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
@@ -36,7 +36,9 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
 
 
         try {
-            selectApiVersion.addItem(DropdownVersion.createLatest());
+            var latestDropdownVersion = DropdownVersion.createLatest();
+
+            selectApiVersion.addItem(latestDropdownVersion);
             apiVersionResolver
                     .supportedVersions()
                     .stream()
@@ -44,7 +46,12 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
                     .map(DropdownVersion::fromApiVersion)
                     .forEach(v -> selectApiVersion.addItem(v))
             ;
-            selectApiVersion.setSelectedItem(DropdownVersion.fromApiVersion(config.selectedFactorioVersion));
+
+            if (config.useLatestVersion) {
+                selectApiVersion.setSelectedItem(latestDropdownVersion);
+            } else {
+                selectApiVersion.setSelectedItem(DropdownVersion.fromApiVersion(config.selectedFactorioVersion));
+            }
 
             // hide error message
             selectApiVersion.setEnabled(true);

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import java.util.Collections;
 import java.util.Objects;
 
 public class FactorioAutocompletionConfig implements SearchableConfigurable {
@@ -38,7 +39,9 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
             selectApiVersion.addItem(DropdownVersion.createLatest());
             apiVersionResolver
                     .supportedVersions()
-                    .stream().map(DropdownVersion::fromApiVersion)
+                    .stream()
+                    .sorted(Collections.reverseOrder())
+                    .map(DropdownVersion::fromApiVersion)
                     .forEach(v -> selectApiVersion.addItem(v))
             ;
             selectApiVersion.setSelectedItem(DropdownVersion.fromApiVersion(config.selectedFactorioVersion));
@@ -48,7 +51,9 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
             loadError.setVisible(false);
             enableFactorioIntegrationCheckBox.setEnabled(true);
             reloadButton.setEnabled(config.integrationActive);
-        } catch (Exception e) {
+        }
+        // todo catch only connection problems and wrote correct message
+        catch (Exception e) {
             // show error message
             selectApiVersion.setEnabled(false);
             loadError.setText("Error loading Factorio versions. You need to have active internet connection to change these settings");

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
@@ -23,7 +23,7 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
     private FactorioAutocompletionState config;
     private JPanel rootPanel;
     private JCheckBox enableFactorioIntegrationCheckBox;
-    private JComboBox selectApiVersion;
+    private JComboBox<FactorioVersion> selectApiVersion;
     private JLabel loadError;
     private JButton reloadButton;
 

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
@@ -111,7 +111,7 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
 
         config.integrationActive = enableIntegration;
 
-        if (!config.selectedFactorioVersion.equals(selectApiVersion.getSelectedItem())) {
+        if (!config.selectedFactorioVersion.equals(getSelectedVersion())) {
             // New Factorio Version selected
             // remove old apis
             ApiParser.removeCurrentAPI(project);

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
@@ -6,10 +6,10 @@ import com.intellij.openapi.options.SearchableConfigurable;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.NlsContexts;
 import com.intellij.util.text.SemVer;
+import moe.knox.factorio.core.version.FactorioApiVersion;
 import moe.knox.factorio.core.parser.ApiParser;
 import moe.knox.factorio.core.parser.LuaLibParser;
 import moe.knox.factorio.core.parser.PrototypeParser;
-import moe.knox.factorio.intellij.FactorioAutocompletionState.FactorioVersion;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jsoup.Jsoup;
@@ -28,7 +28,7 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
     private FactorioAutocompletionState config;
     private JPanel rootPanel;
     private JCheckBox enableFactorioIntegrationCheckBox;
-    private JComboBox<FactorioVersion> selectApiVersion;
+    private JComboBox<FactorioApiVersion> selectApiVersion;
     private JLabel loadError;
     private JButton reloadButton;
 
@@ -66,9 +66,9 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
         });
     }
 
-    private Set<FactorioVersion> getVersions() throws IOException {
-        Set<FactorioVersion> result = new HashSet<>();
-        result.add(FactorioVersion.createLatest());
+    private Set<FactorioApiVersion> getVersions() throws IOException {
+        Set<FactorioApiVersion> result = new HashSet<>();
+        result.add(FactorioApiVersion.createLatest());
 
         Document mainPageDoc = Jsoup.connect(ApiParser.factorioApiBaseLink).get();
         Elements allLinks = mainPageDoc.select("a");
@@ -78,7 +78,7 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
                 continue;
             }
 
-            var factorioVersion = FactorioVersion.createVersion(semVer.getRawVersion());
+            var factorioVersion = FactorioApiVersion.createVersion(semVer.getRawVersion());
 
             selectApiVersion.addItem(factorioVersion);
         }
@@ -136,7 +136,7 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
 
             // save new settings
             if (selectApiVersion.getSelectedItem() != null) {
-                config.selectedFactorioVersion = (FactorioVersion) selectApiVersion.getSelectedItem();
+                config.selectedFactorioVersion = (FactorioApiVersion) selectApiVersion.getSelectedItem();
             }
         }
 

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.util.NlsContexts;
 import moe.knox.factorio.core.parser.ApiParser;
 import moe.knox.factorio.core.parser.LuaLibParser;
 import moe.knox.factorio.core.parser.PrototypeParser;
+import moe.knox.factorio.intellij.FactorioAutocompletionState.FactorioVersion;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jsoup.Jsoup;
@@ -37,7 +38,7 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
             Document mainPageDoc = Jsoup.connect(ApiParser.factorioApiBaseLink).get();
             Elements allLinks = mainPageDoc.select("a");
             for (Element link : allLinks) {
-                FactorioAutocompletionState.FactorioVersion factorioVersion = new FactorioAutocompletionState.FactorioVersion(link.text(), link.attr("href"));
+                FactorioVersion factorioVersion = new FactorioVersion(link.text(), link.attr("href"));
                 selectApiVersion.addItem(factorioVersion);
             }
             selectApiVersion.setSelectedItem(config.selectedFactorioVersion);
@@ -115,7 +116,7 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
 
             // save new settings
             if (selectApiVersion.getSelectedItem() != null) {
-                config.selectedFactorioVersion = (FactorioAutocompletionState.FactorioVersion) selectApiVersion.getSelectedItem();
+                config.selectedFactorioVersion = (FactorioVersion) selectApiVersion.getSelectedItem();
             }
         }
 

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
@@ -139,12 +139,12 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
 
         reloadButton.setEnabled(enableIntegration);
 
-        config.useLatestVersion = getUseLatestVersion();
+        config.useLatestVersion = isUseLatestVersion();
 
         WriteAction.run(() -> FactorioLibraryProvider.reload());
     }
 
-    private boolean getUseLatestVersion() {
+    private boolean isUseLatestVersion() {
         return Objects.requireNonNull((DropdownVersion) selectApiVersion.getSelectedItem()).isLatest();
     }
 

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
@@ -28,13 +28,13 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
     private JButton reloadButton;
     private final ApiVersionResolver apiVersionResolver;
     @NotNull
-    private final FactorioApiVersion latestExistsVersion;
+    private final FactorioApiVersion latestExistingVersion;
 
     public FactorioAutocompletionConfig(@NotNull Project project) throws IOException {
         this.project = project;
         config = FactorioAutocompletionState.getInstance(project);
         apiVersionResolver = new ApiVersionResolver();
-        latestExistsVersion = apiVersionResolver.supportedVersions().latestVersion();
+        latestExistingVersion = apiVersionResolver.supportedVersions().latestVersion();
 
         enableFactorioIntegrationCheckBox.setSelected(config.integrationActive);
 
@@ -152,7 +152,7 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
         var dropdownVersion = Objects.requireNonNull((DropdownVersion) selectApiVersion.getSelectedItem());
 
         if (dropdownVersion.isLatest()) {
-            return latestExistsVersion;
+            return latestExistingVersion;
         }
 
         return FactorioApiVersion.createVersion(dropdownVersion.version);

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionConfig.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SearchableConfigurable;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.NlsContexts;
+import com.intellij.util.text.SemVer;
 import moe.knox.factorio.core.parser.ApiParser;
 import moe.knox.factorio.core.parser.LuaLibParser;
 import moe.knox.factorio.core.parser.PrototypeParser;
@@ -19,6 +20,7 @@ import org.jsoup.select.Elements;
 import javax.swing.*;
 
 public class FactorioAutocompletionConfig implements SearchableConfigurable {
+    final private SemVer minimumApiJsonVersion = new SemVer("1.1.35", 1, 1, 35);
     Project project;
     private FactorioAutocompletionState config;
     private JPanel rootPanel;
@@ -35,11 +37,18 @@ public class FactorioAutocompletionConfig implements SearchableConfigurable {
 
 
         try {
+            // add latest as first
+            selectApiVersion.addItem(FactorioVersion.createLatest());
+
             Document mainPageDoc = Jsoup.connect(ApiParser.factorioApiBaseLink).get();
             Elements allLinks = mainPageDoc.select("a");
             for (Element link : allLinks) {
                 var factorioVersion = new FactorioVersion(link.text(), link.attr("href"));
-                selectApiVersion.addItem(factorioVersion);
+
+                SemVer semVer = SemVer.parseFromText(link.text());
+                if (semVer != null && semVer.isGreaterOrEqualThan(minimumApiJsonVersion)) {
+                    selectApiVersion.addItem(factorioVersion);
+                }
             }
             selectApiVersion.setSelectedItem(config.selectedFactorioVersion);
 

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionState.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionState.java
@@ -5,9 +5,12 @@ import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.xmlb.XmlSerializerUtil;
+import moe.knox.factorio.core.version.ApiVersionResolver;
 import moe.knox.factorio.core.version.FactorioApiVersion;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
 
 @State(
         name = "FactorioAutocompletionConfig",
@@ -19,9 +22,13 @@ public class FactorioAutocompletionState implements PersistentStateComponent<Fac
     public boolean integrationActive = false;
     public String curVersion = "";
     @NotNull
-    public FactorioApiVersion selectedFactorioVersion = FactorioApiVersion.createLatest();
+    public FactorioApiVersion selectedFactorioVersion;
     public String currentLualibVersion = "";
     public boolean useLatestVersion = true;
+
+    public FactorioAutocompletionState() throws IOException {
+        selectedFactorioVersion = (new ApiVersionResolver()).supportedVersions().latestVersion();
+    }
 
     @Nullable
     @Override

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionState.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionState.java
@@ -35,19 +35,26 @@ public class FactorioAutocompletionState implements PersistentStateComponent<Fac
         return project.getService(FactorioAutocompletionState.class);
     }
 
-    public record FactorioVersion(String desc, String link) {
+    public record FactorioVersion(String version, boolean latest) {
+        private static final String latestVersion = "latest";
+
         @Override
         public String toString() {
-            return desc;
+            if (latest) {
+                return "Latest version";
+            }
+
+            return version;
         }
 
         static FactorioVersion createLatest()
         {
-            return new FactorioVersion("Latest version", "/latest/");
+            return new FactorioVersion(latestVersion, true);
         }
 
-        public boolean isLatest() {
-            return this.desc.equals("Latest version");
+        static FactorioVersion createVersion(String version)
+        {
+            return new FactorioVersion(version, false);
         }
     }
 }

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionState.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionState.java
@@ -48,6 +48,10 @@ public class FactorioAutocompletionState implements PersistentStateComponent<Fac
         public String toString() {
             return desc;
         }
+
+        public boolean isLatest() {
+            return this.desc.equals("Latest version");
+        }
     }
 
     public boolean integrationActive = false;

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionState.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionState.java
@@ -15,48 +15,9 @@ import org.jetbrains.annotations.Nullable;
         }
 )
 public class FactorioAutocompletionState implements PersistentStateComponent<FactorioAutocompletionState> {
-    public static class FactorioVersion {
-        public String desc;
-        public String link;
-
-        public FactorioVersion() {
-            desc = "Latest version";
-            link = "/latest/";
-        }
-
-        public FactorioVersion(String desc, String link) {
-            this.desc = desc;
-            this.link = link;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj == this) {
-                return true;
-            }
-
-            if (!(obj instanceof FactorioVersion)) {
-                return false;
-            }
-
-            FactorioVersion factorioVersion = (FactorioVersion) obj;
-
-            return factorioVersion.desc.equals(desc) && factorioVersion.link.equals(link);
-        }
-
-        @Override
-        public String toString() {
-            return desc;
-        }
-
-        public boolean isLatest() {
-            return this.desc.equals("Latest version");
-        }
-    }
-
     public boolean integrationActive = false;
     public String curVersion = "";
-    public FactorioVersion selectedFactorioVersion = new FactorioVersion();
+    public FactorioVersion selectedFactorioVersion = FactorioVersion.createLatest();
     public String currentLualibVersion = "";
 
     @Nullable
@@ -72,5 +33,21 @@ public class FactorioAutocompletionState implements PersistentStateComponent<Fac
 
     public static FactorioAutocompletionState getInstance(Project project) {
         return project.getService(FactorioAutocompletionState.class);
+    }
+
+    public record FactorioVersion(String desc, String link) {
+        @Override
+        public String toString() {
+            return desc;
+        }
+
+        static FactorioVersion createLatest()
+        {
+            return new FactorioVersion("Latest version", "/latest/");
+        }
+
+        public boolean isLatest() {
+            return this.desc.equals("Latest version");
+        }
     }
 }

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionState.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionState.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.xmlb.XmlSerializerUtil;
+import moe.knox.factorio.core.version.FactorioApiVersion;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -17,7 +18,7 @@ import org.jetbrains.annotations.Nullable;
 public class FactorioAutocompletionState implements PersistentStateComponent<FactorioAutocompletionState> {
     public boolean integrationActive = false;
     public String curVersion = "";
-    public FactorioVersion selectedFactorioVersion = FactorioVersion.createLatest();
+    public FactorioApiVersion selectedFactorioVersion = FactorioApiVersion.createLatest();
     public String currentLualibVersion = "";
 
     @Nullable
@@ -33,28 +34,5 @@ public class FactorioAutocompletionState implements PersistentStateComponent<Fac
 
     public static FactorioAutocompletionState getInstance(Project project) {
         return project.getService(FactorioAutocompletionState.class);
-    }
-
-    public record FactorioVersion(String version, boolean latest) {
-        private static final String latestVersion = "latest";
-
-        @Override
-        public String toString() {
-            if (latest) {
-                return "Latest version";
-            }
-
-            return version;
-        }
-
-        static FactorioVersion createLatest()
-        {
-            return new FactorioVersion(latestVersion, true);
-        }
-
-        static FactorioVersion createVersion(String version)
-        {
-            return new FactorioVersion(version, false);
-        }
     }
 }

--- a/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionState.java
+++ b/src/main/java/moe/knox/factorio/intellij/FactorioAutocompletionState.java
@@ -18,8 +18,10 @@ import org.jetbrains.annotations.Nullable;
 public class FactorioAutocompletionState implements PersistentStateComponent<FactorioAutocompletionState> {
     public boolean integrationActive = false;
     public String curVersion = "";
+    @NotNull
     public FactorioApiVersion selectedFactorioVersion = FactorioApiVersion.createLatest();
     public String currentLualibVersion = "";
+    public boolean useLatestVersion = true;
 
     @Nullable
     @Override

--- a/src/test/java/moe/knox/factorio/core/version/ApiVersionResolverTest.java
+++ b/src/test/java/moe/knox/factorio/core/version/ApiVersionResolverTest.java
@@ -1,0 +1,26 @@
+package moe.knox.factorio.core.version;
+
+import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ApiVersionResolverTest extends TestCase {
+
+    private ApiVersionResolver apiVersionResolver;
+
+    @BeforeEach
+    protected void setUp() {
+        apiVersionResolver = new ApiVersionResolver();
+    }
+
+    @Test
+    void supportedVersions() throws IOException {
+        var versions = apiVersionResolver.supportedVersions();
+
+        assertFalse("Versions cant be empty", versions.isEmpty());
+    }
+}


### PR DESCRIPTION
 - In business logic we use `FactorioApiVersion` class that encapsulate real api version
 - In config we use presentation of version class (`DropdownVersion`) that cant be named as latest
 - Versions parsing moved in own class + add test
 - Set minimal supported version of api
